### PR TITLE
Add cd command, add Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,6 @@ mvn test
 - Java 1.8
 - Scala 2.11
 - Maven 3.0
+
+# Project on Pivotal Tracker:
+https://www.pivotaltracker.com/n/projects/1878017

--- a/src/main/java/ru/spbau/sdcourse/Commands/Cd.java
+++ b/src/main/java/ru/spbau/sdcourse/Commands/Cd.java
@@ -6,11 +6,15 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * @author Dmitriy Baidin on 10/4/2016.
+ * Change environment directory.
+ * Take only one argument - path to directory.
+ * Throw exception if no such directory.
  */
 @BuiltinCommand(name = "cd")
 public class Cd extends Command {
     /**
+     * Create instance of command Cd
+     *
      * @param prev other command which provides input.
      * @param args arguments for command.
      * @param env  environment variables.
@@ -19,6 +23,13 @@ public class Cd extends Command {
         super(prev, args, env);
     }
 
+
+    /**
+     * Change environment directory.
+     * Take only one argument - path to directory.
+     *
+     * @throws Exception if no such directory.
+     */
     @Override
     protected void start() throws Exception {
         if (arguments.size() != 1) {

--- a/src/main/java/ru/spbau/sdcourse/Commands/Cd.java
+++ b/src/main/java/ru/spbau/sdcourse/Commands/Cd.java
@@ -1,0 +1,36 @@
+package ru.spbau.sdcourse.Commands;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Dmitriy Baidin on 10/4/2016.
+ */
+@BuiltinCommand(name = "cd")
+public class Cd extends Command {
+    /**
+     * @param prev other command which provides input.
+     * @param args arguments for command.
+     * @param env  environment variables.
+     */
+    public Cd(Command prev, List<String> args, Map<String, String> env) {
+        super(prev, args, env);
+    }
+
+    @Override
+    protected void start() throws Exception {
+        if (arguments.size() != 1) {
+            throw new RuntimeException("cd: invalid argument count");
+        }
+        Path path = Paths.get(System.getProperty("user.dir")).resolve(arguments.get(0)).normalize().toAbsolutePath();
+        if (!path.toFile().exists()) {
+            throw new RuntimeException("no such directory!" + path.toString());
+        }
+        if (!path.toFile().isDirectory()) {
+            throw new RuntimeException("this is no directory! " + path.toString());
+        }
+        System.setProperty("user.dir", path.toString());
+    }
+}

--- a/src/main/java/ru/spbau/sdcourse/Commands/CommandFactory.java
+++ b/src/main/java/ru/spbau/sdcourse/Commands/CommandFactory.java
@@ -2,6 +2,7 @@ package ru.spbau.sdcourse.Commands;
 
 import org.reflections.util.ClasspathHelper;
 
+import java.io.File;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.util.*;
@@ -24,7 +25,7 @@ public class CommandFactory {
         Set<URL> urls = Collections.singleton(ClasspathHelper.forClass(Command.class));
 
         builtinCommands = urls.stream()
-                .map(url -> Paths.get(url.getPath(), packagePath))
+                .map(url -> new File(ClasspathHelper.forClass(Command.class).getPath(), packagePath).toPath())
                 .flatMap(path -> Arrays.stream(path.toFile().list()))
                 .filter(s -> s.endsWith(".class"))
                 .map(s -> packageName + "." + s.substring(0, s.length() - 6))

--- a/src/test/java/ru/spbau/sdcourse/ShellTest.java
+++ b/src/test/java/ru/spbau/sdcourse/ShellTest.java
@@ -1,6 +1,7 @@
 package ru.spbau.sdcourse;
 
 import org.junit.*;
+import org.junit.rules.TemporaryFolder;
 import ru.spbau.sdcourse.Commands.*;
 
 import java.nio.file.Paths;
@@ -20,6 +21,9 @@ public class ShellTest {
     private String testfile1 = "test1.txt";
     private String testfile2 = "test2.txt";
     private String execFile = "exec";
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     ExecutorService executor = Executors.newCachedThreadPool();
 
@@ -157,5 +161,16 @@ public class ShellTest {
         List<Command> commands = Arrays.asList(reader, echo, args, wc, checker);
         List<Future<Void>> results = commands.stream().map(executor::submit).collect(Collectors.toList());
         for(Future<Void> f : results) f.get();
+    }
+
+    @Test(timeout = 1000)
+    public void cdTest() throws Exception {
+        temporaryFolder.newFile("fileName123");
+        Cd cd = new Cd(null, Collections.singletonList(temporaryFolder.getRoot().getAbsolutePath()), null);
+        Ls ls = new Ls(null, Collections.emptyList(), null);
+        TestChecker checker = new TestChecker(ls, Collections.singletonList("fileName123"));
+        cd.call();
+        ls.call();
+        checker.call();
     }
 }


### PR DESCRIPTION
Add only cd, cause ls already implemented.
- Very simple way to add new command. All classes has comments, so I quickly figured out how to add new command. :+1: 
- No Windows support. :-1: 
